### PR TITLE
matplotlib 3.3 or newer needed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,5 @@ setuptools.setup(
     
     python_requires=">=3.5",
     
-    install_requires=["matplotlib", "numpy"],
+    install_requires=["matplotlib>=3.3", "numpy"],
 )


### PR DESCRIPTION
Hey - great repo!
Calling `matplotlib.axis.Axis.set_major_formatter` with a function was introduced in [matplotlib v3.3.0](https://github.com/matplotlib/matplotlib/pull/16715). Added this requirement to the `setup.py`. 